### PR TITLE
fix entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ chown -R ${PUID}:${PGID} /opt/alist/
 
 umask ${UMASK}
 
-exec su-exec ${PUID}:${PGID} nohup aria2c \
+exec su-exec root:root nohup aria2c \
   --enable-rpc \
   --rpc-allow-origin-all \
   --conf-path=/root/.aria2/aria2.conf \


### PR DESCRIPTION
因aria2 文件位于/root下，所以无需继承外部用户权限。