### PR TITLE
fix aria2 can not run when PUID is not equal to 0

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 chown -R ${PUID}:${PGID} /opt/alist/
+chown -R ${PUID}:${PGID} /root/
 
 umask ${UMASK}
 


### PR DESCRIPTION
 ([#6612](https://github.com/alist-org/alist/issues/6612)) Modify the owner of conf directory before startup